### PR TITLE
updated bug that gift content still showed when users were switched

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -303,6 +303,8 @@ $(document).ready(function () {
     $("#persons-content").hide();
     // empty the buttons - this will be necessary when a new user starts a list
     $("#person-buttons").empty();
+    // hide the gift content for new user
+    $("#gift-content").hide();
 
     // reset the ID and data to "" - the follow code will assign the ID based on the e-mail
     id = "";


### PR DESCRIPTION
Acceptance Criteria;
When a user is switched from one to another, the gift content should hide. It should reappear when a new person is clicked on.